### PR TITLE
Support .NET Framework 4.6.1.

### DIFF
--- a/StandardSocketsHttpHandler/Net/Http/Extensions/HttpRequestMessageExtensions.cs
+++ b/StandardSocketsHttpHandler/Net/Http/Extensions/HttpRequestMessageExtensions.cs
@@ -8,8 +8,12 @@ namespace System.Net.Http
     {
         public static bool HasHeaders(this HttpRequestMessage request)
         {
+#if NET461
+            string headersFieldName = "headers";
+#else
             // Note: The field name is _headers in .NET core 
             string headersFieldName = RuntimeUtils.IsDotNetFramework() ? "headers" : "_headers";
+#endif            
             FieldInfo headersField = typeof(HttpRequestMessage).GetField(headersFieldName, BindingFlags.Instance | BindingFlags.NonPublic);
             HttpRequestHeaders headers = (HttpRequestHeaders)headersField.GetValue(request);
             return headers != null;

--- a/StandardSocketsHttpHandler/Net/Http/SocketsHttpHandler/CancellationHelper.cs
+++ b/StandardSocketsHttpHandler/Net/Http/SocketsHttpHandler/CancellationHelper.cs
@@ -25,7 +25,7 @@ namespace System.Net.Http
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that triggered the cancellation.</param>
         /// <returns>The cancellation exception.</returns>
         internal static Exception CreateOperationCanceledException(Exception innerException, CancellationToken cancellationToken) =>
-#if NETSTANDARD2_0
+#if NETSTANDARD2_0 || NET461
             new TaskCanceledException(s_cancellationMessage, innerException); // TCE for compatibility with other handlers that use TaskCompletionSource.TrySetCanceled()
 #else
             new TaskCanceledException(s_cancellationMessage, innerException, cancellationToken); // TCE for compatibility with other handlers that use TaskCompletionSource.TrySetCanceled()

--- a/StandardSocketsHttpHandler/Net/Http/SocketsHttpHandler/HttpConnection.cs
+++ b/StandardSocketsHttpHandler/Net/Http/SocketsHttpHandler/HttpConnection.cs
@@ -1167,7 +1167,7 @@ namespace System.Net.Http
         private Task WriteToStreamAsync(ReadOnlyMemory<byte> source)
         {
             if (NetEventSource.IsEnabled) Trace($"Writing {source.Length} bytes.");
-#if NETSTANDARD2_0
+#if NETSTANDARD2_0 || NET461
             return _stream.WriteAsync(source);
 #else
             return _stream.WriteAsync(source).AsTask();

--- a/StandardSocketsHttpHandler/StandardSocketsHttpHandler.csproj
+++ b/StandardSocketsHttpHandler/StandardSocketsHttpHandler.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net461</TargetFrameworks>
     <RootNamespace>System.Net.Http</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
-    <Version>2.2.0.2</Version>
+    <Version>2.3.0.0-beta01</Version>
     <Authors>Tal Aloni</Authors>
     <PackageDescription>StandardSocketsHttpHandler is a backport of SocketsHttpHandler to .NET Standard 2.0</PackageDescription>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
@@ -13,6 +13,12 @@
     <RepositoryUrl>https://github.com/TalAloni/StandardSocketsHttpHandler</RepositoryUrl>
   </PropertyGroup>
 
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
+		<PackageReference Include="System.Net.Http" Version="4.1.2" />
+		<PackageReference Include="System.Buffers" Version="4.4.0" />
+		<PackageReference Include="System.Memory" Version="4.5.1" />
+	</ItemGroup>
+	
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' ">
     <Compile Remove="HashCode.cs" />
     <Compile Remove="IO\Extensions\StreamExtensions.cs" />

--- a/StandardSocketsHttpHandler/Utils/RuntimeUtils.cs
+++ b/StandardSocketsHttpHandler/Utils/RuntimeUtils.cs
@@ -6,9 +6,13 @@ namespace System
     {
         public static bool IsDotNetFramework()
         {
+#if NET461
+            return true;
+#else
             const string DotnetFrameworkDescription = ".NET Framework";
             string frameworkDescription = RuntimeInformation.FrameworkDescription;
             return frameworkDescription.StartsWith(DotnetFrameworkDescription);
+#endif
         }
     }
 }


### PR DESCRIPTION
These changes are to support .NET Framework 4.6.1. Initially, I used runtime utilities to figure out if the framework is 4.6.1. but it seems like a dent in performance. Eventually, this library is going to be run within one of the .NET Framework or .NET Core (or .NET 6.0 in the future) even if it is transitive dependency. 