### PR TITLE
Make it work with Mono runtime

### DIFF
--- a/StandardSocketsHttpHandler/Net/Http/Extensions/HttpRequestMessageExtensions.cs
+++ b/StandardSocketsHttpHandler/Net/Http/Extensions/HttpRequestMessageExtensions.cs
@@ -10,7 +10,8 @@ namespace System.Net.Http
         {
             // Note: The field name is _headers in .NET core 
             bool isDotNetFramework = RuntimeUtils.IsDotNetFramework();
-            string headersFieldName = isDotNetFramework ? "headers" : "_headers";
+            bool isDotNetFrameworkOrMono = isDotNetFramework || RuntimeUtils.IsMono();
+            string headersFieldName = isDotNetFrameworkOrMono ? "headers" : "_headers";
             FieldInfo headersField = typeof(HttpRequestMessage).GetField(headersFieldName, BindingFlags.Instance | BindingFlags.NonPublic);
             if (headersField == null && isDotNetFramework)
             {

--- a/StandardSocketsHttpHandler/Utils/RuntimeUtils.cs
+++ b/StandardSocketsHttpHandler/Utils/RuntimeUtils.cs
@@ -10,5 +10,12 @@ namespace System
             string frameworkDescription = RuntimeInformation.FrameworkDescription;
             return frameworkDescription.StartsWith(DotnetFrameworkDescription);
         }
+
+        public static bool IsMono()
+        {
+            const string MonoDescription = "Mono";
+            string frameworkDescription = RuntimeInformation.FrameworkDescription;
+            return frameworkDescription.StartsWith(MonoDescription);
+        }
     }
 }


### PR DESCRIPTION
Hi,
I recently made an experiment, using this in Unity Editor (which runs with Mono runtime). The experiment used dotnet grpc listening on a named pipe. 
This lib is awesome, with this simple fix (making sure HasHeaders check is done correctly on Mono), I was able to get HTTP2 + ConnectCallback allowing me to connect to my GRPC service via named pipes instead of TCP :)