### PR TITLE
Mono require the fallback for Mac (and probably Linux) distributions

### DIFF
--- a/StandardSocketsHttpHandler/Net/Http/Extensions/HttpRequestMessageExtensions.cs
+++ b/StandardSocketsHttpHandler/Net/Http/Extensions/HttpRequestMessageExtensions.cs
@@ -6,11 +6,12 @@ namespace System.Net.Http
 {
     internal static class HttpRequestMessageExtensions
     {
-        // depending on runtime the backing field for headers is either _headers or headers
-        // _headers in .net core and some .net fx and mono versions.
+        // Depending on runtime the backing field for headers is either _headers or headers:
+        // _headers in .net core and some .net fx and mono versions (.NET Framework 4.6.1, Mono on Mac)
         // headers in other .net fx / mono versions.
         static FieldInfo _headersField = typeof(HttpRequestMessage).GetField("_headers", BindingFlags.Instance | BindingFlags.NonPublic) ??
             typeof(HttpRequestMessage).GetField("headers", BindingFlags.Instance | BindingFlags.NonPublic);
+
         public static bool HasHeaders(this HttpRequestMessage request)
         {
             HttpRequestHeaders headers = (HttpRequestHeaders)_headersField.GetValue(request);

--- a/StandardSocketsHttpHandler/Net/Http/Extensions/HttpRequestMessageExtensions.cs
+++ b/StandardSocketsHttpHandler/Net/Http/Extensions/HttpRequestMessageExtensions.cs
@@ -9,7 +9,7 @@ namespace System.Net.Http
         // Depending on runtime the backing field for headers is either _headers or headers:
         // _headers in .net core and some .net fx and mono versions (.NET Framework 4.6.1, Mono on Mac)
         // headers in other .net fx / mono versions.
-        private static FieldInfo s_headersField = typeof(HttpRequestMessage).GetField("_headers", BindingFlags.Instance | BindingFlags.NonPublic) ??
+        private static readonly FieldInfo s_headersField = typeof(HttpRequestMessage).GetField("_headers", BindingFlags.Instance | BindingFlags.NonPublic) ??
             typeof(HttpRequestMessage).GetField("headers", BindingFlags.Instance | BindingFlags.NonPublic);
 
         public static bool HasHeaders(this HttpRequestMessage request)

--- a/StandardSocketsHttpHandler/Net/Http/Extensions/HttpRequestMessageExtensions.cs
+++ b/StandardSocketsHttpHandler/Net/Http/Extensions/HttpRequestMessageExtensions.cs
@@ -9,12 +9,12 @@ namespace System.Net.Http
         // Depending on runtime the backing field for headers is either _headers or headers:
         // _headers in .net core and some .net fx and mono versions (.NET Framework 4.6.1, Mono on Mac)
         // headers in other .net fx / mono versions.
-        static FieldInfo _headersField = typeof(HttpRequestMessage).GetField("_headers", BindingFlags.Instance | BindingFlags.NonPublic) ??
+        private static FieldInfo s_headersField = typeof(HttpRequestMessage).GetField("_headers", BindingFlags.Instance | BindingFlags.NonPublic) ??
             typeof(HttpRequestMessage).GetField("headers", BindingFlags.Instance | BindingFlags.NonPublic);
 
         public static bool HasHeaders(this HttpRequestMessage request)
         {
-            HttpRequestHeaders headers = (HttpRequestHeaders)_headersField.GetValue(request);
+            HttpRequestHeaders headers = (HttpRequestHeaders)s_headersField.GetValue(request);
             return headers != null;
         }
     }

--- a/StandardSocketsHttpHandler/Net/Http/Extensions/HttpRequestMessageExtensions.cs
+++ b/StandardSocketsHttpHandler/Net/Http/Extensions/HttpRequestMessageExtensions.cs
@@ -6,20 +6,14 @@ namespace System.Net.Http
 {
     internal static class HttpRequestMessageExtensions
     {
+        // depending on runtime the backing field for headers is either _headers or headers
+        // _headers in .net core and some .net fx and mono versions.
+        // headers in other .net fx / mono versions.
+        static FieldInfo _headersField = typeof(HttpRequestMessage).GetField("_headers", BindingFlags.Instance | BindingFlags.NonPublic) ??
+            typeof(HttpRequestMessage).GetField("headers", BindingFlags.Instance | BindingFlags.NonPublic);
         public static bool HasHeaders(this HttpRequestMessage request)
         {
-            // Note: The field name is _headers in .NET core 
-            bool isDotNetFramework = RuntimeUtils.IsDotNetFramework();
-            bool isDotNetFrameworkOrMono = isDotNetFramework || RuntimeUtils.IsMono();
-            string headersFieldName = isDotNetFrameworkOrMono ? "headers" : "_headers";
-            FieldInfo headersField = typeof(HttpRequestMessage).GetField(headersFieldName, BindingFlags.Instance | BindingFlags.NonPublic);
-            if (headersField == null && isDotNetFramework)
-            {
-                // Fallback for .NET Framework 4.6.1
-                headersFieldName = "_headers";
-                headersField = typeof(HttpRequestMessage).GetField(headersFieldName, BindingFlags.Instance | BindingFlags.NonPublic);
-            }
-            HttpRequestHeaders headers = (HttpRequestHeaders)headersField.GetValue(request);
+            HttpRequestHeaders headers = (HttpRequestHeaders)_headersField.GetValue(request);
             return headers != null;
         }
     }

--- a/StandardSocketsHttpHandler/Utils/RuntimeUtils.cs
+++ b/StandardSocketsHttpHandler/Utils/RuntimeUtils.cs
@@ -10,12 +10,5 @@ namespace System
             string frameworkDescription = RuntimeInformation.FrameworkDescription;
             return frameworkDescription.StartsWith(DotnetFrameworkDescription);
         }
-
-        public static bool IsMono()
-        {
-            const string MonoDescription = "Mono";
-            string frameworkDescription = RuntimeInformation.FrameworkDescription;
-            return frameworkDescription.StartsWith(MonoDescription);
-        }
     }
 }


### PR DESCRIPTION
After some tests on mac, it seems the Mac version of mono has the "_headers" field... so we need the fallback for mono as well :/.