### PR TITLE
Do not send "Content-Length: 0" for OPTIONS and DELETE methods

### DIFF
--- a/StandardSocketsHttpHandler/Net/Http/SocketsHttpHandler/HttpConnection.cs
+++ b/StandardSocketsHttpHandler/Net/Http/SocketsHttpHandler/HttpConnection.cs
@@ -441,7 +441,8 @@ namespace System.Net.Http
                 {
                     // Write out Content-Length: 0 header to indicate no body,
                     // unless this is a method that never has a body.
-                    if (!ReferenceEquals(normalizedMethod, HttpMethod.Get) && !ReferenceEquals(normalizedMethod, HttpMethod.Head) && !ReferenceEquals(normalizedMethod, HttpMethodUtils.Connect))
+                    if (!ReferenceEquals(normalizedMethod, HttpMethod.Get) && !ReferenceEquals(normalizedMethod, HttpMethod.Head) && !ReferenceEquals(normalizedMethod, HttpMethodUtils.Connect)
+                         && !ReferenceEquals(normalizedMethod, HttpMethod.Options) && !ReferenceEquals(normalizedMethod, HttpMethod.Delete))
                     {
                         await WriteBytesAsync(s_contentLength0NewlineAsciiBytes).ConfigureAwait(false);
                     }


### PR DESCRIPTION
Hi!

While I really didn't do a good job with #13 this one should be much more straightforward. Currently StandardSocketsHttpHandler erroneously sends "Content-Length: 0" for content-less OPTIONS and DELETE requests. This was [fixed some time ago](https://github.com/dotnet/runtime/commit/765e7510f96840063cb8e224dc0eac192f9414e8#diff-afa71e6e87f982add8d12cdebcf3216ad79c340e8e6867a520cc26ead2268c6a) in the original repository.
This PR is a minimal required backport for the fix.