### PR TITLE
Backport cancellation deadlock fix

### DIFF
--- a/StandardSocketsHttpHandler/Net/Http/SocketsHttpHandler/HttpConnection.cs
+++ b/StandardSocketsHttpHandler/Net/Http/SocketsHttpHandler/HttpConnection.cs
@@ -198,16 +198,6 @@ namespace System.Net.Http
             return null;
         }
 
-        public bool IsNewConnection
-        {
-            get
-            {
-                // This is only valid when we are not actually processing a request.
-                Debug.Assert(_currentRequest == null);
-                return (_readAheadTask == null);
-            }
-        }
-
         public bool CanRetry
         {
             get
@@ -1494,7 +1484,7 @@ namespace System.Net.Http
             }
         }
 
-        public void Acquire()
+        internal void Acquire()
         {
             Debug.Assert(_currentRequest == null);
             Debug.Assert(!_inUse);
@@ -1502,7 +1492,7 @@ namespace System.Net.Http
             _inUse = true;
         }
 
-        public void Release()
+        internal void Release()
         {
             Debug.Assert(_inUse);
 


### PR DESCRIPTION
Hi. This is a backport of a (critical) [cancellation deadlock fix](https://github.com/dotnet/runtime/commit/47f71a91e4704c13b290c6ad52dfdc1b017e1d4a) (we were getting it multiple times a week with certain servers).

I had to backport some of the previous commits also to apply the deadlock fix since it was based on HTTP/2 class split `HttpConnection`->`HttpConnectionBase`.