### PR TITLE
Use TryAddWithoutValidation to prevent parsing potentially illegal headers

### DIFF
--- a/StandardSocketsHttpHandler/Net/Http/Extensions/HttpContentHeadersExtensions.cs
+++ b/StandardSocketsHttpHandler/Net/Http/Extensions/HttpContentHeadersExtensions.cs
@@ -10,7 +10,7 @@ namespace System.Net.Http
         {
             foreach (KeyValuePair<string, IEnumerable<string>> header in sourceHeaders)
             {
-                headers.Add(header.Key, header.Value);
+                headers.TryAddWithoutValidation(header.Key, header.Value);
             }
         }
     }


### PR DESCRIPTION
Hi!

Currently, when automatic decompression is used, the headers are copied between instances of `HttpContent` to facilitate the decompression. Unfortunately, the `HttpContentHeaders.Add` method used in `HttpContentHeadersExtensions` performs header parsing, which tests whether the headers are valid. This leads to exceptions like "The format of value '0' is invalid." triggered by .NET Framework's `DateHeaderParser` [being too strict](https://github.com/microsoft/referencesource/blob/main/System/net/System/Net/Http/Headers/DateHeaderParser.cs#L23) when parsing the `Expires: 0` header, while [RFC 9111](https://www.rfc-editor.org/rfc/rfc9111.html#name-expires) explicitly mentions this:
> A cache recipient MUST interpret invalid date formats, especially the value "0", as representing a time in the past (i.e., "already expired").

Also, this can lead to a misinterpretation of other header fields that do not perfectly roundtrip by a parse->convert step of `HttpContentHeaders.Add`. I believe that decompression should not intervene into header processing and pass content headers as-is.

To improve this, I propose using `HttpContentHeaders.TryAddWithoutValidation` that will copy the headers without any other processing. I'm not sure whether the result value should be checked and acted upon by, for example, throwing some kind of exception since this might defeat the original purpose.

Thanks for looking into this.
